### PR TITLE
Provider name faas to openfaas

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
 
 functions:


### PR DESCRIPTION
Updated Provider name from the now invalid `faas` to `openfaas` in stack.yml